### PR TITLE
feat(index.ts) merge() method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,7 @@ export class Objex<K, V> extends Map<K, V> {
 	 * @returns {Objex} The filtered Objex collection
 	 */
 	public filter<T>(func: (val: V, key: K, objex: this) => boolean): this {
+		if (!func) return this;
 		const filtered = new this.constructor[Symbol.species]<K, V>() as this;
 		for (let [key, value] of this) {
 			if (func(value, key, this)) filtered.set(key, value);
@@ -299,4 +300,17 @@ export class Objex<K, V> extends Map<K, V> {
 			throw new TypeError("[Objex Error] Cannot reduce empty Objex.");
 		return acc;
 	}
+
+	public merge<T>(...obj: any[]) {
+		for (const objex of obj) {
+			if (objex instanceof Map) {
+				for (const [key, val] of objex) {
+					if (this.has(key)) return;
+					this.set(key, val)
+				}
+			}
+		}
+		return this;
+	}
+
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,7 +258,7 @@ export class Objex<K, V> extends Map<K, V> {
 	}
 
 	/**
-	 * Check if atlesst one element passes a test
+	 * Check if at least one element passes a test
 	 * @param {Function} func - The function that needs to be satisfied
 	 * @returns {boolean} If any element was found
 	 */
@@ -300,6 +300,11 @@ export class Objex<K, V> extends Map<K, V> {
 			throw new TypeError("[Objex Error] Cannot reduce empty Objex.");
 		return acc;
 	}
+	/**
+	 * Merge Objexes into the given objex - existing keys will NOT be overwritten
+	 * @param {...Objex} - The Objexes to be merged
+	 * @returns {Objex} - The merged Objex
+	 */
 
 	public merge<T>(...obj: any[]) {
 		for (const objex of obj) {


### PR DESCRIPTION
**Changes**
This PR adds a new method named `merge()`, which "merges" the given Objexes into the base Objex (which is the one that the method was called on)

**Note:** In the interest of consistency, this method has been configured to ensure that existing keys will not be overwritten

**Compatibility**
Since this is a feature addition, nothing is broken

**Why it should be merged**
a new utility method is always helpful